### PR TITLE
Don't delete file if it doesn't exist

### DIFF
--- a/lib/geckodriver/helper.rb
+++ b/lib/geckodriver/helper.rb
@@ -65,6 +65,7 @@ module Geckodriver
     end
 
     def remove_if_stale
+      return if !File.exists?(binary_path)
       File.delete(binary_path) unless current_or_newer_version?
     end
 


### PR DESCRIPTION
It looks like this is the cause of the missing helper: https://collegevinehq.slack.com/archives/C02TD03N93M/p1665079944526889

Without this change, when I try to run geckodriver it fails because it tries to delete a file that doesn't exist.